### PR TITLE
Add QSV and improve general encoding settings

### DIFF
--- a/files/firstLaunch.js
+++ b/files/firstLaunch.js
@@ -63,7 +63,8 @@ module.exports = firstLaunch = async () => {
                 choices: [
                     "CPU",
                     "NVIDIA GPU (NVENC)",
-                    "AMD GPU (VCE)"
+                    "AMD GPU (VCE)",
+                    "Intel GPU (QSV)"
                 ],
                 default: "CPU"
             }])
@@ -81,6 +82,11 @@ module.exports = firstLaunch = async () => {
                 } else if (answers.renderType === "AMD GPU (VCE)") {
                     renderingType = "gpu"
                     config.encoder = "amd"
+                    writeConfig()
+                    settingsGenerator("change")
+                } else if (answers.renderType === "Intel GPU (QSV)") {
+                    renderingType = "gpu"
+                    config.encoder = "intel"
                     writeConfig()
                     settingsGenerator("change")
                 }

--- a/files/settingsGenerator.js
+++ b/files/settingsGenerator.js
@@ -61,20 +61,26 @@ module.exports = settingsGenerator = async (type) => {
             switch (true) {
                 case config.encoder === "cpu":
                     danserConfig.Recording.Encoder = "libx264"
-                    danserConfig.Recording.EncoderOptions = "-crf 20"
-                    danserConfig.Recording.Preset = "fast"
+                    danserConfig.Recording.EncoderOptions = "-crf 21 -g 450"
+                    danserConfig.Recording.Preset = "faster"
                     writeDanserConfig()
                     break
                 case config.encoder === "nvidia":
                     danserConfig.Recording.Encoder = "h264_nvenc"
-                    danserConfig.Recording.EncoderOptions = "-rc constqp -qp 20"
+                    danserConfig.Recording.EncoderOptions = "-rc constqp -qp 26 -g 450"
                     danserConfig.Recording.Preset = "slow"
                     writeDanserConfig()
                     break
                 case config.encoder === "amd":
                     danserConfig.Recording.Encoder = "h264_amf"
-                    danserConfig.Recording.EncoderOptions = "-rc cqp -qp_p 17 -qp_i 17"
-                    danserConfig.Recording.Preset = "slow"
+                    danserConfig.Recording.EncoderOptions = "-rc cqp -qp_p 17 -qp_i 17 -quality quality"
+                    danserConfig.Recording.Preset = "slow" // H264_amf doesn't support -preset, instead using -quality (for some reason), keeping preset so it doesn't break anything
+                    writeDanserConfig()
+                    break
+                case config.encoder === "intel":
+                    danserConfig.Recording.Encoder = "h264_qsv"
+                    danserConfig.Recording.EncoderOptions = "-global_quality 31 -g 450 -look_ahead 1"
+                    danserConfig.Recording.Preset = "veryslow"
                     writeDanserConfig()
                     break
             }


### PR DESCRIPTION
Aims to improve consistency between encoders and majorly decrease bitrates at a small expense of quality.
Sample files (zinput.mkv and zinput_tough.mkv are input files encoded at CRF5 x264 veryslow): https://mega.nz/file/K9tkxKBb#szrP-CIU5vIkOrMh1fNVebvOdUtKqUKykAo83f3XJOA
Keeping as draft PR for now as it's still untested (although should work) - since I have all of the encoders at hand I'll test it soon