### PR TITLE
Fix QSV on older devices

### DIFF
--- a/files/settingsGenerator.js
+++ b/files/settingsGenerator.js
@@ -79,7 +79,7 @@ module.exports = settingsGenerator = async (type) => {
                     break
                 case config.encoder === "intel":
                     danserConfig.Recording.Encoder = "h264_qsv"
-                    danserConfig.Recording.EncoderOptions = "-global_quality 31 -g 450 -look_ahead 1"
+                    danserConfig.Recording.EncoderOptions = "-global_quality 31 -g 450"
                     danserConfig.Recording.Preset = "veryslow"
                     writeDanserConfig()
                     break


### PR DESCRIPTION
h264_qsv is picky about arguments and having -look_ahead in that spot _actually_ activates it, which was not happening while I was testing with just ffmpeg with the argument in a slightly different spot. Ugh. 
This will decrease quality on newer QSV, however it is still great even without look_ahead.