### PR TITLE
Fix unzipping issues and fix exit function usage.

### DIFF
--- a/files/clientUpdater.js
+++ b/files/clientUpdater.js
@@ -9,9 +9,9 @@ module.exports = async () => {
     const output = path.resolve("files/client-latest.zip")
 
     let download = wget.download(link, output)
-    download.on("error", err => {
+    download.on("error", async (err) => {
         console.log(err)
-        exit()
+        await exit()
     })
     download.on("start", fileSize => {
         console.log(`Downloading the client update at ${link}, ${fileSize} bytes to download...`)
@@ -24,13 +24,13 @@ module.exports = async () => {
                         path: `.`
                     })
                 )
-                .on("close", () => {
+                .on("close", async () => {
                     console.log(`Finished updating the client. You can now restart it.`)
-                    exit()
+                    await exit()
                 })
         } catch (err) {
             console.log("An error occured while unpacking: " + err)
-            exit()
+            (async () => await exit())
         }
     })
 }

--- a/files/firstLaunch.js
+++ b/files/firstLaunch.js
@@ -17,10 +17,10 @@ module.exports = async () => {
         serverUrl = "https://ordr-api.issou.best/servers"
     }
 
-    await axios.request(serverUrl).catch(error => {
+    await axios.request(serverUrl).catch(async error => {
         if (!error.status) {
             console.log("Network error. Maybe the o!rdr server is offline or you are not connected to Internet.")
-            exit()
+            await exit()
         }
     })
 
@@ -89,7 +89,7 @@ module.exports = async () => {
             if (confirmedPrompt) {
                 downloadBenchMap()
             } else {
-                exit()
+                await exit()
             }
         }
 
@@ -280,7 +280,7 @@ module.exports = async () => {
             if (cont.continue) {
                 chooseRenderingType()
             } else {
-                exit()
+                await exit()
             }
         })
 
@@ -364,7 +364,7 @@ module.exports = async () => {
             }
 
             console.log("Please download librespeed-cli and place it in the files folder.")
-            exit()
+            await exit()
         }
     }
 
@@ -432,10 +432,10 @@ module.exports = async () => {
                     console.log('The only currently available relay is "us" (in the USA, near NYC). You can go back to direct upload by using "direct" instead.')
                 }
             })
-            .catch(error => {
+            .catch(async (error) => {
                 if (error.response) {
                     console.log(`Something wrong happened! ${error}`)
-                    exit()
+                    await exit()
                 }
             })
 

--- a/files/firstLaunch.js
+++ b/files/firstLaunch.js
@@ -6,8 +6,7 @@ const wget = require("wget-improved")
 const config = require(process.cwd() + "/config.json")
 const settingsGenerator = require("./settingsGenerator")
 const danserUpdater = require("./danserUpdater")
-const { exit } = require("./util")
-const unzipper = require("unzipper")
+const { exit, asyncExtract } = require("./util")
 
 module.exports = async () => {
     var avgFps, renderingType, danserExecutable, serverUrl
@@ -341,11 +340,9 @@ module.exports = async () => {
 
                 // unzip librespeed-cli
                 console.log(`Unzipping librespeed-cli...`)
-                fs.createReadStream(`${process.cwd()}/files/librespeed-cli/librespeed-cli.zip`)
-                    .pipe(unzipper.Extract({ path: `${process.cwd()}/files/librespeed-cli/` }))
 
-                    // when unzipping is done, delete zip file
-                    .on("close", () => {
+                asyncExtract(`${process.cwd()}/files/librespeed-cli/librespeed-cli.zip`)
+                    .then(() => {
                         console.log(`Finished unzipping librespeed-cli.`)
                         fs.unlinkSync(`${process.cwd()}/files/librespeed-cli/librespeed-cli.zip`)
 
@@ -353,6 +350,9 @@ module.exports = async () => {
                         if (process.platform === "linux") fs.chmodSync("files/librespeed-cli/librespeed-cli", "755")
 
                         runSpeedtest()
+                    })
+                    .catch((err) => {
+                        console.error(err)
                     })
             })
         }

--- a/files/firstLaunch.js
+++ b/files/firstLaunch.js
@@ -341,7 +341,7 @@ module.exports = async () => {
                 // unzip librespeed-cli
                 console.log(`Unzipping librespeed-cli...`)
 
-                asyncExtract(`${process.cwd()}/files/librespeed-cli/librespeed-cli.zip`)
+                asyncExtract(`${process.cwd()}/files/librespeed-cli/librespeed-cli.zip`, `${process.cwd()}/files/librespeed-cli/`, 'librespeed', '/files/librespeed-cli/librespeed-cli.zip')
                     .then(() => {
                         console.log(`Finished unzipping librespeed-cli.`)
                         fs.unlinkSync(`${process.cwd()}/files/librespeed-cli/librespeed-cli.zip`)

--- a/files/firstLaunch.js
+++ b/files/firstLaunch.js
@@ -344,7 +344,6 @@ module.exports = async () => {
                 asyncExtract(`${process.cwd()}/files/librespeed-cli/librespeed-cli.zip`, `${process.cwd()}/files/librespeed-cli/`, 'librespeed', '/files/librespeed-cli/librespeed-cli.zip')
                     .then(() => {
                         console.log(`Finished unzipping librespeed-cli.`)
-                        fs.unlinkSync(`${process.cwd()}/files/librespeed-cli/librespeed-cli.zip`)
 
                         // chmod when on linux
                         if (process.platform === "linux") fs.chmodSync("files/librespeed-cli/librespeed-cli", "755")

--- a/files/server.js
+++ b/files/server.js
@@ -60,15 +60,11 @@ exports.startServer = async () => {
         dataProcessor(data)
     })
 
-<<<<<<< HEAD
-    ioClient.on("version_too_old", async () => {
-=======
     ioClient.on("cool_message", message => {
         console.log(`The o!rdr server says: ${message}`)
     })
 
-    ioClient.on("version_too_old", () => {
->>>>>>> 5d580c244dfa5fe21cbdcc79c4724845280aa8fa
+    ioClient.on("version_too_old", async () => {
         console.log("This version of the client is too old! Restart it to apply the update.")
         config.needUpdate = true
         writeConfig()

--- a/files/server.js
+++ b/files/server.js
@@ -58,16 +58,16 @@ exports.startServer = async () => {
         dataProcessor(data)
     })
 
-    ioClient.on("version_too_old", () => {
+    ioClient.on("version_too_old", async () => {
         console.log("This version of the client is too old! Restart it to apply the update.")
         config.needUpdate = true
         writeConfig()
-        exit()
+        await exit()
     })
 
-    ioClient.on("not_approved", () => {
+    ioClient.on("not_approved", async () => {
         console.log("This client still hasn't been approved to be used on o!rdr. You'll be pinged on the o!rdr Discord server when this client will be approved. It shouldn't take more than 2 days.")
-        exit()
+        await exit()
     })
 
     ioClient.on("abort_render", () => {

--- a/files/util.js
+++ b/files/util.js
@@ -1,4 +1,3 @@
-const fs = require("fs")
 const wget = require("wget-improved")
 const AdmZip = require("adm-zip")
 
@@ -32,14 +31,12 @@ exports.asyncDownload = async (link, output, filename, type) => {
 exports.asyncExtract = async (input, output, filename, type) => {
     await new Promise((resolve, reject) => {
         try {
-            console.log(`Unpacking ${type} ${filename}.`)
             const zip = new AdmZip(input);
             zip.extractAllTo(output);
-            console.log(`Finished unpacking ${type} ${filename}.`)
             resolve()
         } catch (err) {
-            console.log("An error occured while unpacking the skin: " + err)
-            (async () => { this.exit() })
+            console.log("An error occured while unpacking the skin: " + err);
+            (async () => { this.exit() });
             reject()
         }
     })

--- a/files/util.js
+++ b/files/util.js
@@ -3,18 +3,20 @@ const wget = require("wget-improved")
 const AdmZip = require("adm-zip")
 
 exports.exit = () => {
-    console.log("Press any key to exit.")
-    process.stdin.setRawMode(true)
-    process.stdin.on("data", process.exit.bind(process, 0))
+    return new Promise(() => {
+        console.log("Press any key to exit.")
+        process.stdin.setRawMode(true)
+        process.stdin.on("data", process.exit.bind(process, 0))
+    })
 }
 
 exports.asyncDownload = async (link, output, filename, type) => {
     await new Promise((resolve, reject) => {
         let download = wget.download(link, output)
 
-        download.on("error", err => {
+        download.on("error", async (err) => {
             console.log(err)
-            this.exit()
+            await this.exit()
             reject()
         })
         download.on("start", fileSize => {
@@ -37,7 +39,7 @@ exports.asyncExtract = async (input, output, filename, type) => {
             resolve()
         } catch (err) {
             console.log("An error occured while unpacking the skin: " + err)
-            this.exit()
+            (async () => { this.exit() })
             reject()
         }
     })

--- a/files/util.js
+++ b/files/util.js
@@ -1,6 +1,6 @@
 const fs = require("fs")
 const wget = require("wget-improved")
-const unzipper = require("unzipper")
+const AdmZip = require("adm-zip")
 
 exports.exit = () => {
     console.log("Press any key to exit.")
@@ -31,13 +31,10 @@ exports.asyncExtract = async (input, output, filename, type) => {
     await new Promise((resolve, reject) => {
         try {
             console.log(`Unpacking ${type} ${filename}.`)
-            fs.createReadStream(input)
-                .pipe(unzipper.Extract({ path: output }))
-                .on("close", () => {
-                    console.log(`Finished unpacking ${type} ${filename}.`)
-                    fs.unlinkSync(input)
-                    resolve()
-                })
+            const zip = new AdmZip(input);
+            zip.extractAllTo(output);
+            console.log(`Finished unpacking ${type} ${filename}.`)
+            resolve()
         } catch (err) {
             console.log("An error occured while unpacking the skin: " + err)
             this.exit()

--- a/files/util.js
+++ b/files/util.js
@@ -1,5 +1,6 @@
 const wget = require("wget-improved")
 const AdmZip = require("adm-zip")
+const fs = require("fs")
 
 exports.exit = () => {
     return new Promise(() => {
@@ -33,6 +34,8 @@ exports.asyncExtract = async (input, output, filename, type) => {
         try {
             const zip = new AdmZip(input);
             zip.extractAllTo(output);
+            fs.unlinkSync(input);
+            console.log(`Finished unpacking ${type} ${filename}.`);
             resolve()
         } catch (err) {
             console.log("An error occured while unpacking the skin: " + err);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "MasterIO",
   "license": "MIT",
   "dependencies": {
+    "adm-zip": "^0.5.9",
     "axios": "^0.21.1",
     "discord-rich-presence": "^0.0.8",
     "form-data": "^4.0.0",
@@ -17,8 +18,7 @@
     "nanoid": "^3.1.23",
     "socket.io-client": "^4.1.3",
     "systeminformation": "^5.8.0",
-    "unzipper": "^0.10.11",
-    "wget-improved": "^3.2.1"
+    "wget-improved": "^3.3.1"
   },
   "nodemonConfig": {
     "ignore": [


### PR DESCRIPTION
Duplicate of #8, but with additional changes and for the rev19 client.

For unzipping-related changes, refer to the body of #8.

The exit function wouldn't stop the execution of the script, but sent an exit message and waited for input. 
By calling exit asynchronously, it allows for the execution of the script to halt.
Before, this was problematic when exit was called due to an error, but the script would continue and cause more errors. 