### PR TITLE
Display different outdated message for source/compiled client

### DIFF
--- a/files/server.js
+++ b/files/server.js
@@ -69,8 +69,12 @@ exports.startServer = async () => {
     })
 
     ioClient.on("version_too_old", async () => {
-        console.log("This version of the client is too old! Restart it to apply the update.")
-        config.needUpdate = true
+        if (process.pkg) {
+            console.log("This client is too old! The precompiled version does not support auto-update!\nPlease download the latest release from https://github.com/MasterIO02/ordr-client/releases")
+        } else {
+            console.log("This version of the client is too old! Restart it to apply the update.")
+            config.needUpdate = true
+        }
         writeConfig()
         await exit()
     })

--- a/files/server.js
+++ b/files/server.js
@@ -70,7 +70,7 @@ exports.startServer = async () => {
 
     ioClient.on("version_too_old", async () => {
         if (process.pkg) {
-            console.log("This client is too old! The precompiled version does not support auto-update!\nPlease download the latest release from https://github.com/MasterIO02/ordr-client/releases")
+            console.log("This client is too old! The precompiled version does not support auto-update! Please download the latest release from https://github.com/MasterIO02/ordr-client/releases")
         } else {
             console.log("This version of the client is too old! Restart it to apply the update.")
             config.needUpdate = true


### PR DESCRIPTION
This will check whether the current process is pkg packaged (precompiled exe) and tell the user to update without forcing the client to try update, which it cannot. Otherwise it'll do the normal action since it's running from source of informing the user it's too old and will update itself.