### PR TITLE
Check client version on startup

### DIFF
--- a/files/checkDanserVersion.js
+++ b/files/checkDanserVersion.js
@@ -1,6 +1,6 @@
 const { startServer } = require("./server")
 
-module.exports = async () => {
+module.exports = async (danserHashes, danserVersion) => {
     var filename
     if (process.platform === "win32") {
         filename = "files/danser/danser.exe"
@@ -15,12 +15,10 @@ module.exports = async () => {
         const data = input.read()
         if (data) hash.update(data)
         else {
-            const axios = require("axios")
-            const { data: data } = await axios.get("https://apis.issou.best/ordr/dansermd5")
-            if (data.correctHashes.indexOf(hash.digest("hex")) === -1) {
+            if (danserHashes.indexOf(hash.digest("hex")) === -1) {
                 console.log("The version of danser is too old, updating now")
                 const danserUpdater = require("./danserUpdater")
-                await danserUpdater(() => {}, data.version)
+                await danserUpdater(() => {}, danserVersion)
             } else {
                 startServer()
             }

--- a/files/clientUpdater.js
+++ b/files/clientUpdater.js
@@ -2,6 +2,10 @@ const path = require("path")
 const { exit, asyncDownload, asyncExtract } = require("./util")
 
 module.exports = async () => {
+    if (process.pkg) {
+        console.log("The pre-compiled version does not support auto-update. Get the latest client at https://github.com/MasterIO02/ordr-client/releases")
+        await exit()
+    }
     let link = `https://dl.issou.best/ordr/client-latest.zip`
     const outputZip = path.resolve("files/client-latest.zip")
 

--- a/files/server.js
+++ b/files/server.js
@@ -3,7 +3,8 @@ const fs = require("fs")
 const dataProcessor = require("./dataProcessor")
 const { isRendering, abortRender } = require("./danserHandler")
 const { exit, readConfig, writeConfig } = require("./util")
-const version = 23
+const { version } = require("./../main")
+
 let ioClient
 
 let config

--- a/files/server.js
+++ b/files/server.js
@@ -73,9 +73,9 @@ exports.startServer = async () => {
     })
 
     ioClient.on("version_too_old", async () => {
-        console.log("This version of the client is too old! Restart it to apply the update.")
-        config = await writeConfig("needUpdate", true)
-        await exit()
+        console.log("This version of the client is too old!")
+        const clientUpdater = require("./clientUpdater")
+        clientUpdater()
     })
 
     ioClient.on("abort_render", () => {

--- a/files/util.js
+++ b/files/util.js
@@ -67,7 +67,6 @@ let emptyConfig = {
         clientUrl: "",
         apiUrl: ""
     },
-    needUpdate: false,
     deleteRenderedVideos: true,
     showFullDanserLogs: true,
     showFullFFmpegLogs: true,

--- a/main.js
+++ b/main.js
@@ -14,15 +14,10 @@ async function main() {
 
     const { data: data } = await axios.get("http://apis.issou.best/ordr/dansermd5")
 
-    if (config.needUpdate || version != data.clientVersion) {
+    if (version != data.clientVersion) {
         const clientUpdater = require("./files/clientUpdater")
-        if (process.pkg) {
-            console.log("Detected different version compared to server. The pre-compiled version does not support auto-update. Get the latest client at https://github.com/MasterIO02/ordr-client/releases")
-            await exit()
-        } else {
-            console.log("Client version seems incorrect or out of date. Running update.")
-            clientUpdater()
-        }
+        console.log("Client version seems incorrect or out of date. Running updater.")
+        clientUpdater()
     } else if (config.id && config.customServer.apiUrl === "") {
         if (config.discordPresence && (config.customServer.apiUrl === "" || config.dev)) {
             const { startPresence } = require("./files/presence")


### PR DESCRIPTION
Moved version to main.js, exports it back to server.js for client runtime, and compares to server on every startup in main.js

Checks for packaged version (executable) via process.pkg to display a different message.